### PR TITLE
Disable relative URLs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 baseURL: "https://tools.scientific-python.org/"
 title: "Tools"
 theme: scientific-python-hugo-theme
-relativeURLs: true
 disableKinds: ["term", "taxonomy"]
 
 markup:


### PR DESCRIPTION
Not sure why we enabled this. But my understanding is this is not recommended.

It states here https://gohugo.io/content-management/urls/#relative-urls
```
Do not enable this option unless you are creating a serverless site, navigable via the file system.
```