### PR TITLE
DOC: minor clarification for the SPIN acronym

### DIFF
--- a/content/utilities/index.md
+++ b/content/utilities/index.md
@@ -18,7 +18,7 @@ Implements lazy loading as described in [SPEC1](https://scientific-python.org/sp
 type = 'card'
 header = '[spin](https://github.com/scientific-python/spin)'
 body = '''
-**S**cientific **P**ython **D**eveloper **I**ncantations: an extendible tool that
+**S**cientific **P**ython **IN**cantations: an extendible tool that
 provides uniform aliases for build tasks across the ecosystem (`spin build`, `spin docs`, etc.).
 '''
 


### PR DESCRIPTION
A one-line change to match the acronym formatting in spin's readme: https://github.com/scientific-python/spin/blob/main/README.md?plain=1#L1